### PR TITLE
export Event type and properties

### DIFF
--- a/sdk/trace/basetypes.go
+++ b/sdk/trace/basetypes.go
@@ -22,8 +22,8 @@ import (
 
 // event is used to describe an event with a message string and set of
 // attributes.
-type event struct {
-	msg        string
-	attributes []core.KeyValue
-	time       time.Time
+type Event struct {
+	Msg        string
+	Attributes []core.KeyValue
+	Time       time.Time
 }

--- a/sdk/trace/export.go
+++ b/sdk/trace/export.go
@@ -86,7 +86,7 @@ type SpanData struct {
 	EndTime time.Time
 	// The values of Attributes each have type string, bool, or int64.
 	Attributes               map[string]interface{}
-	MessageEvents            []event
+	MessageEvents            []Event
 	Status                   codes.Code
 	HasRemoteParent          bool
 	DroppedAttributeCount    int

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -158,10 +158,10 @@ func (s *span) AddEvent(ctx context.Context, msg string, attrs ...core.KeyValue)
 func (s *span) addEventWithTimestamp(timestamp time.Time, msg string, attrs ...core.KeyValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messageEvents.add(event{
-		msg:        msg,
-		attributes: attrs,
-		time:       timestamp,
+	s.messageEvents.add(Event{
+		Msg:        msg,
+		Attributes: attrs,
+		Time:       timestamp,
 	})
 }
 
@@ -210,10 +210,10 @@ func (s *span) makeSpanData() *SpanData {
 	return &sd
 }
 
-func (s *span) interfaceArrayToMessageEventArray() []event {
-	messageEventArr := make([]event, 0)
+func (s *span) interfaceArrayToMessageEventArray() []Event {
+	messageEventArr := make([]Event, 0)
 	for _, value := range s.messageEvents.queue {
-		messageEventArr = append(messageEventArr, value.(event))
+		messageEventArr = append(messageEventArr, value.(Event))
 	}
 	return messageEventArr
 }

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -245,7 +245,7 @@ func TestEvents(t *testing.T) {
 	}
 
 	for i := range got.MessageEvents {
-		if !checkTime(&got.MessageEvents[i].time) {
+		if !checkTime(&got.MessageEvents[i].Time) {
 			t.Error("exporting span: expected nonzero event Time")
 		}
 	}
@@ -258,9 +258,9 @@ func TestEvents(t *testing.T) {
 		ParentSpanID:    sid,
 		Name:            "span0",
 		HasRemoteParent: true,
-		MessageEvents: []event{
-			{msg: "foo", attributes: []core.KeyValue{k1v1}},
-			{msg: "bar", attributes: []core.KeyValue{k2v2, k3v3}},
+		MessageEvents: []Event{
+			{Msg: "foo", Attributes: []core.KeyValue{k1v1}},
+			{Msg: "bar", Attributes: []core.KeyValue{k2v2, k3v3}},
 		},
 	}
 	if diff := cmp.Diff(got, want, cmp.AllowUnexported(event{})); diff != "" {
@@ -292,7 +292,7 @@ func TestEventsOverLimit(t *testing.T) {
 	}
 
 	for i := range got.MessageEvents {
-		if !checkTime(&got.MessageEvents[i].time) {
+		if !checkTime(&got.MessageEvents[i].Time) {
 			t.Error("exporting span: expected nonzero event Time")
 		}
 	}
@@ -304,9 +304,9 @@ func TestEventsOverLimit(t *testing.T) {
 		},
 		ParentSpanID: sid,
 		Name:         "span0",
-		MessageEvents: []event{
-			{msg: "foo", attributes: []core.KeyValue{k1v1}},
-			{msg: "bar", attributes: []core.KeyValue{k2v2, k3v3}},
+		MessageEvents: []Event{
+			{Msg: "foo", Attributes: []core.KeyValue{k1v1}},
+			{Msg: "bar", Attributes: []core.KeyValue{k2v2, k3v3}},
 		},
 		DroppedMessageEventCount: 2,
 		HasRemoteParent:          true,


### PR DESCRIPTION
We need to export this type and properties in order to create child spans for MessageEvents

Testing: I was unable to run the tests locally due to the import path rules, but made the same changes in the opentelemetry master branch and the tests passed there.